### PR TITLE
Updated hooks to more up to date commits

### DIFF
--- a/example.pre-commit-config.yaml
+++ b/example.pre-commit-config.yaml
@@ -4,12 +4,12 @@
 # See https://eng.inky.wtf/docs/technical/git/pre-commit for info on how to edit this file.
 repos:
   - repo: https://github.com/chainguard-dev/pre-commit-hooks
-    rev: e4f3bba353cc583ce73f660dcf217e245fd681d3
+    rev: 71fca50bcd1006b5cbcf71f03a3b493f48c4af7f
     hooks:
       - id: check-for-epoch-bump
       - id: shellcheck-run-steps
   - repo: https://github.com/chainguard-dev/yam
-    rev: 498642e77997ba79709f43a7ee2c84b12b2145bb # v0.2.12
+    rev: 693d578a25dccd5beb548984d7a3cbda40c3af41  # frozen: v0.2.16
     hooks:
       - id: yam
   # TODO: Swap with CG repo: - repo: https://github.com/wolfi-dev/wolfictl
@@ -18,7 +18,7 @@ repos:
     hooks:
       - id: wolfictl-lint
   - repo: https://github.com/golangci/misspell
-    rev: 528d713e620bdf4b41849db93cb489c4fef9f5c5 # v0.6.0
+    rev: e78f9b6cd537559a24525b6ea7e182794edfd31f  # frozen: v0.7.0
     hooks:
       - id: misspell
   - repo: https://github.com/pre-commit/pre-commit-hooks


### PR DESCRIPTION
This also fixes an issue installing the yam environment, where go-1.23 is no longer available. 