### PR TITLE
Issue 11 adds capability for multiple documents in yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,7 @@ repos:
     rev: cef0300fd0fc4d2a87a85fa2093c6b283ea36f4b # v5.0.0
     hooks:
       - id: check-yaml
+        args: ["--allow-multiple-documents"]
       - id: forbid-submodules
       - id: check-added-large-files
       - id: check-case-conflict


### PR DESCRIPTION
Fixes: https://github.com/chainguard-dev/pre-commit-hooks/issues/11

Currently Yaml using multiple documents will not be allowed and would fail the pre-commit. Using the additional arguments it allows these types of files