### PR TITLE
shellcheck_run_steps: use `:Z` volume mount for SELinux relabeling if suppored

### DIFF
--- a/pre_commit_hooks/shellcheck_run_steps.py
+++ b/pre_commit_hooks/shellcheck_run_steps.py
@@ -86,7 +86,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         default=[
             "docker",
             "run",
-            f"--volume={os.getcwd()}:/mnt",
+            f"--volume={os.getcwd()}:/mnt:Z",
             "--rm",
             DefaultShellCheckImage,
         ],
@@ -116,7 +116,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 [
                     "docker",
                     "run",
-                    f"--volume={os.getcwd()}:/work",
+                    f"--volume={os.getcwd()}:/work:Z",
                     "--rm",
                     MelangeImage,
                     "compile",


### PR DESCRIPTION
This is usually required on systems that use SELinux due to labeling issues. `:Z` makes it so an unique SELinux label gets written to all the files under (mount) so that only the container running can access it, `:z` is the same thing but if you want to share directories between containers. This _should_ resolve an issue where running the shellcheck hook breaks on Fedora/SELinux-enabled systems and _should_ be a no-op for non SELinux-enabled systems/MacOS
