### PR TITLE
chore: pin melange version to 0.31.6

### DIFF
--- a/pre_commit_hooks/shellcheck_run_steps.py
+++ b/pre_commit_hooks/shellcheck_run_steps.py
@@ -16,7 +16,7 @@ yaml = ruamel.yaml.YAML(typ="safe")
 # Please provide the output of `grype koalaman/shellcheck@sha256:<newhash>`
 # in your PR when bumping. Referenced by SHA for safety.
 DefaultShellCheckImage = "koalaman/shellcheck@sha256:652a5a714dc2f5f97e36f565d4f7d2322fea376734f3ec1b04ed54ce2a0b124f"
-MelangeImage = "cgr.dev/chainguard/melange:latest"
+MelangeImage = "cgr.dev/chainguard/melange:0.31.6"
 
 
 # Returns False if shellcheck reports issues


### PR DESCRIPTION
we had this commit https://github.com/chainguard-dev/melange/commit/0cbbd8bc31b6f44f7d411e7b8e0dc6621cb03d12
which made var-transforms resolution a bit stricter.

this commit pins melange version to 0.31.6 while we fix incorrect var-transforms

Signed-off-by: kranurag7 <81210977+kranurag7@users.noreply.github.com>
