### PR TITLE
Fix regex in epoch_sed

### DIFF
--- a/scripts/check-for-epoch-bump.sh
+++ b/scripts/check-for-epoch-bump.sh
@@ -15,7 +15,7 @@ epoch_grep() {
 }
 
 epoch_sed() {
-    sed -r 's/^[[:space:]]+epoch:[[:space:]]+([0-9])+.*$/\1/'
+    sed -r 's/^[[:space:]]+epoch:[[:space:]]+([0-9]+).*$/\1/'
 }
 
 for yaml_file in "$@"; do


### PR DESCRIPTION
The `epoch_sec()` function will now ignore anything after the number in an epoch line.

Addresses #24. :crossed_fingers: 