### PR TITLE
chore: use melange latest again

### DIFF
--- a/pre_commit_hooks/shellcheck_run_steps.py
+++ b/pre_commit_hooks/shellcheck_run_steps.py
@@ -17,7 +17,7 @@ yaml = ruamel.yaml.YAML(typ="safe")
 # in your PR when bumping. Referenced by SHA for safety.
 DefaultShellCheckImage = "koalaman/shellcheck@sha256:652a5a714dc2f5f97e36f565d4f7d2322fea376734f3ec1b04ed54ce2a0b124f"
 # 0.31.6 pinning to resolve var-transforms linting error
-MelangeImage = "cgr.dev/chainguard/melange@sha256:f90bc7ef37f080cd9e0919d8ff96163a57551de515c6e8c7c228157176a0436b"
+MelangeImage = "cgr.dev/chainguard/melange:latest"
 
 
 # Returns False if shellcheck reports issues


### PR DESCRIPTION
now that we've reverted melange var-transform strictness, this commit falls back to using melange latest image again.