### PR TITLE
check-for-epoch-bump: enforce epoch bump when package moves between dirs

### DIFF
--- a/scripts/check-for-epoch-bump.sh
+++ b/scripts/check-for-epoch-bump.sh
@@ -45,7 +45,19 @@ for yaml_file in "$@"; do
 
     # Extract version and epoch from the file on the main branch using git show
     # Treat missing file as version 0 and epoch 0
-    main_content="$(git show main:"$yaml_file" 2>/dev/null)"
+    # Try all three known package directories so epoch bumps are enforced when
+    # a package is moved between os/, enterprise-packages/, and extra-packages/.
+    first_component="${yaml_file%%/*}"
+    rest_of_path="${yaml_file#*/}"
+    main_content=""
+    if [[ "$first_component" == "os" || "$first_component" == "enterprise-packages" || "$first_component" == "extra-packages" ]]; then
+        for prefix in "os" "enterprise-packages" "extra-packages"; do
+            main_content="$(git show main:"${prefix}/${rest_of_path}" 2>/dev/null)"
+            [ -n "$main_content" ] && break
+        done
+    else
+        main_content="$(git show main:"$yaml_file" 2>/dev/null)"
+    fi
     if [ -z "$main_content" ]; then
         version_main="0"
         epoch_main="0"


### PR DESCRIPTION
## Summary

- When a package is moved between `os/`, `enterprise-packages/`, and `extra-packages/`, the script now tries all three candidate paths on `main` to find the previous version/epoch.
- Previously, a moved package would appear as brand-new (version 0 / epoch 0) so the bump check was silently skipped.
- Falls back to the original single-path lookup for files outside those three directories.

## Test plan

- [x] Modify a file under `os/` with the same version/epoch — confirm warning is emitted
- [x] Move a package from `enterprise-packages/foo/foo.yaml` to `os/foo/foo.yaml` without bumping epoch — confirm warning is emitted
- [x] Move a package and bump the epoch — confirm check passes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)