### PR TITLE
CI hardening: drop persisted checkout credential in lint workflow

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -21,7 +21,7 @@ jobs:
       with:
         egress-policy: audit
 
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # ratchet:actions/checkout@v4.2.2
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
     # Unroll pre-commit/actions as currently it references actions/cache without a by-digest pin
     # https://github.com/pre-commit/pre-commit/issues/3672

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -22,6 +22,8 @@ jobs:
         egress-policy: audit
 
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        persist-credentials: false
     - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
     # Unroll pre-commit/actions as currently it references actions/cache without a by-digest pin
     # https://github.com/pre-commit/pre-commit/issues/3672

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -9,11 +9,13 @@ on:
     paths:
       - '.github/workflows/**'
       - '.github/actions/**'
+      - '.github/zizmor.yml'
   push:
     branches: ['main']
     paths:
       - '.github/workflows/**'
       - '.github/actions/**'
+      - '.github/zizmor.yml'
 
 permissions: {}
 

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,5 @@
+rules:
+  # Cosmetic pedantic-only finding (zizmor concurrency-limits) — low
+  # security value; suppressed at the repo level per campaign convention.
+  concurrency-limits:
+    disable: true


### PR DESCRIPTION
## Summary

Small GitHub Actions security-hardening changes to `lint.yaml`, surfaced by a
`zizmor` audit of `.github/`. No behavioral change to the lint job.

## Changes

- **`.github/workflows/lint.yaml`** — set `persist-credentials: false` on the
  `actions/checkout` step. The job only runs `setup-python` and `pre-commit`,
  with no git writes, so the checkout has no reason to leave the `GITHUB_TOKEN`
  in the local git config where later steps could read it. This closes the
  `artipacked` credential-persistence finding.

- **`.github/workflows/lint.yaml`** — normalize the checkout pin's version
  comment from `# ratchet:actions/checkout@v4.2.2` to `# v4.2.2`, matching the
  plain `# vX.Y.Z` convention used by every other pin in the repo. The SHA is
  unchanged (it is exactly `v4.2.2`); this only tidies the lone non-standard
  annotation.

- **`.github/zizmor.yml`** (new) — disable the cosmetic pedantic-persona rule
  `concurrency-limits`, with the zizmor workflow's `paths:` triggers extended
  to include the new config so edits to it re-run the check.

## Testing

- `zizmor` (whole repo): **no findings** after the change.
- `actionlint`: clean.
- Patches apply cleanly on top of `main`; all workflows still parse.
- Independently reviewed by a second pass: no blocking issues.

Refs: PSEC-923