### PR TITLE
fix: pass per-repo pipeline dirs to melange compile

### DIFF
--- a/pre_commit_hooks/shellcheck_run_steps.py
+++ b/pre_commit_hooks/shellcheck_run_steps.py
@@ -19,6 +19,27 @@ DefaultShellCheckImage = "koalaman/shellcheck@sha256:652a5a714dc2f5f97e36f565d4f
 # 0.31.6 pinning to resolve var-transforms linting error
 MelangeImage = "cgr.dev/chainguard/melange:latest"
 
+# Pipeline directories per package tier, matching stereo's dirToPipelineDirs.
+# Paths are relative to the repo root (the Docker /work mount).
+PIPELINE_DIRS: dict[str, list[str]] = {
+    "os/": ["./os/pipelines/"],
+    "extra-packages/": ["./extra-packages/pipelines/", "./pipelines/os"],
+    "enterprise-packages/": [
+        "./enterprise-packages/pipelines/",
+        "./pipelines/",
+        "./pipelines/os",
+    ],
+}
+
+
+def _pipeline_dirs_for(filename: str) -> list[str]:
+    """Return the --pipeline-dir flags appropriate for *filename*."""
+    for prefix, dirs in PIPELINE_DIRS.items():
+        if filename.startswith(prefix):
+            return [f"--pipeline-dir={d}" for d in dirs]
+    # Fallback: derive from the file's own directory (original behaviour).
+    return [f"--pipeline-dir=./{os.path.dirname(filename)}/pipelines"]
+
 
 # Returns False if shellcheck reports issues
 def do_shellcheck(
@@ -122,7 +143,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                     MelangeImage,
                     "compile",
                     f"--arch={arch}",
-                    f"--pipeline-dir=./{os.path.dirname(filename)}/pipelines",
+                    *_pipeline_dirs_for(filename),
                     filename,
                 ],
                 stdout=compiled_out,


### PR DESCRIPTION
## Summary

- The `shellcheck-run-steps` hook hardcoded a single `--pipeline-dir` flag derived from the file's parent directory. This fails for packages in `enterprise-packages/` and `extra-packages/` that reference pipelines from other tiers (e.g. `pipelines/py/pip-vendor-bump.yaml`).
- Adds a `PIPELINE_DIRS` mapping matching stereo's `dirToPipelineDirs` so each package tier gets the correct set of `--pipeline-dir` flags passed to `melange compile`.
- Falls back to the original single-dir behavior for files not in a known tier.

Fixes the failure Chris Herborth hit when committing `enterprise-packages/graalvm-25.yaml` in a git worktree.

Resolves OS-2428

🤖 Generated with [Claude Code](https://claude.com/claude-code)